### PR TITLE
Whitelabel: Adjust login screen for chatbegruenung

### DIFF
--- a/app/views/WorkspaceView/index.tsx
+++ b/app/views/WorkspaceView/index.tsx
@@ -3,6 +3,7 @@ import { Text, View } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { CompositeNavigationProp } from '@react-navigation/core';
+import { shallowEqual } from 'react-redux';
 
 import { OutsideModalParamList, OutsideParamList } from '../../stacks/types';
 import I18n from '../../i18n';
@@ -11,11 +12,12 @@ import { useWorkspaceDomain } from '../../lib/hooks/useWorkspaceDomain';
 import { useTheme } from '../../theme';
 import FormContainer, { FormContainerInner } from '../../containers/FormContainer';
 import { IAssetsFavicon512 } from '../../definitions/IAssetsFavicon512';
-import { getShowLoginButton } from '../../selectors/login';
+import { getShowLoginButton, IServices } from '../../selectors/login';
 import ServerAvatar from './ServerAvatar';
 import styles from './styles';
 import { useAppSelector } from '../../lib/hooks';
 import RegisterDisabledComponent from './RegisterDisabledComponent';
+import * as ServiceLogin from '../../containers/LoginServices/serviceLogin';
 
 type TNavigation = CompositeNavigationProp<
 	NativeStackNavigationProp<OutsideParamList, 'WorkspaceView'>,
@@ -41,6 +43,8 @@ const WorkspaceView = () => {
 
 	const workspaceDomain = useWorkspaceDomain();
 
+	const services = useAppSelector(state => state.login.services as IServices, shallowEqual);
+
 	const {
 		Accounts_iframe_enabled,
 		Assets_favicon_512,
@@ -64,11 +68,8 @@ const WorkspaceView = () => {
 	);
 
 	const login = () => {
-		if (Accounts_iframe_enabled) {
-			navigation.navigate('AuthenticationWebView', { url: server, authType: 'iframe' });
-			return;
-		}
-		navigation.navigate('LoginView', { title: workspaceDomain });
+		// Directly use the only configured login via saml to avoid the need for a second click on a login button
+		ServiceLogin.onPressSaml({ loginService: Object.values(services)[0], server });
 	};
 
 	const register = () => {

--- a/app/views/WorkspaceView/index.tsx
+++ b/app/views/WorkspaceView/index.tsx
@@ -51,7 +51,9 @@ const WorkspaceView = () => {
 	useLayoutEffect(() => {
 		navigation.setOptions({
 			// Use the app name instead of the server name as header title
-			title: appConfig.name
+			title: appConfig.name,
+			// Hide the back button in the header
+			headerLeft: () => <View />
 		});
 	}, [navigation, workspaceDomain]);
 

--- a/app/views/WorkspaceView/index.tsx
+++ b/app/views/WorkspaceView/index.tsx
@@ -16,7 +16,6 @@ import { getShowLoginButton, IServices } from '../../selectors/login';
 import ServerAvatar from './ServerAvatar';
 import styles from './styles';
 import { useAppSelector } from '../../lib/hooks';
-import RegisterDisabledComponent from './RegisterDisabledComponent';
 import * as ServiceLogin from '../../containers/LoginServices/serviceLogin';
 
 type TNavigation = CompositeNavigationProp<
@@ -85,11 +84,10 @@ const WorkspaceView = () => {
 					<Text style={[styles.serverUrl, { color: colors.fontSecondaryInfo }]}>{Site_Url}</Text>
 				</View>
 				{showLoginButton ? <Button title={I18n.t('Login')} type='primary' onPress={login} testID='workspace-view-login' /> : null}
+				{/* Hide login via GrünesNetz hint as we directly open the login  */}
 				{showRegistrationButton ? (
 					<Button title={I18n.t('Create_account')} type='secondary' onPress={register} testID='workspace-view-register' />
-				) : (
-					<RegisterDisabledComponent />
-				)}
+				) : null}
 			</FormContainerInner>
 		</FormContainer>
 	);

--- a/app/views/WorkspaceView/index.tsx
+++ b/app/views/WorkspaceView/index.tsx
@@ -16,6 +16,7 @@ import { getShowLoginButton, IServices } from '../../selectors/login';
 import ServerAvatar from './ServerAvatar';
 import styles from './styles';
 import { useAppSelector } from '../../lib/hooks';
+import appConfig from '../../../app.json';
 import * as ServiceLogin from '../../containers/LoginServices/serviceLogin';
 
 type TNavigation = CompositeNavigationProp<
@@ -44,20 +45,13 @@ const WorkspaceView = () => {
 
 	const services = useAppSelector(state => state.login.services as IServices, shallowEqual);
 
-	const {
-		Accounts_iframe_enabled,
-		Assets_favicon_512,
-		Site_Name,
-		Site_Url,
-		inviteLinkToken,
-		registrationForm,
-		server,
-		showLoginButton
-	} = useWorkspaceViewSelector();
+	const { Accounts_iframe_enabled, Assets_favicon_512, Site_Url, inviteLinkToken, registrationForm, server, showLoginButton } =
+		useWorkspaceViewSelector();
 
 	useLayoutEffect(() => {
 		navigation.setOptions({
-			title: workspaceDomain
+			// Use the app name instead of the server name as header title
+			title: appConfig.name
 		});
 	}, [navigation, workspaceDomain]);
 
@@ -80,7 +74,8 @@ const WorkspaceView = () => {
 			<FormContainerInner>
 				<View style={styles.alignItemsCenter}>
 					<ServerAvatar url={server} image={Assets_favicon_512?.url ?? Assets_favicon_512?.defaultUrl} />
-					<Text style={[styles.serverName, { color: colors.fontTitlesLabels }]}>{Site_Name}</Text>
+					{/* Display the app name instead of the server name */}
+					<Text style={[styles.serverName, { color: colors.fontTitlesLabels }]}>{appConfig.name}</Text>
 					<Text style={[styles.serverUrl, { color: colors.fontSecondaryInfo }]}>{Site_Url}</Text>
 				</View>
 				{showLoginButton ? <Button title={I18n.t('Login')} type='primary' onPress={login} testID='workspace-view-login' /> : null}


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue below. -->

- Directly open login via saml
- Hide login via GrünesNetz hint
- Show app name instead of server name
- Hide back button on login screen