### PR TITLE
7: Configure deep links

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -49,9 +49,9 @@
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="https" android:host="go.rocket.chat" android:path="/invite" />
-                <data android:scheme="https" android:host="go.rocket.chat" android:path="/auth" />
-                <data android:scheme="https" android:host="go.rocket.chat" android:path="/room" />
+                <data android:scheme="https" android:host="chatbegruenung.de" android:path="/invite" />
+                <data android:scheme="https" android:host="chatbegruenung.de" android:path="/auth" />
+                <data android:scheme="https" android:host="chatbegruenung.de" android:path="/room" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -59,7 +59,7 @@ interface IState {
 
 const parseDeepLinking = (url: string) => {
 	if (url) {
-		url = url.replace(/rocketchat:\/\/|https:\/\/go.rocket.chat\//, '');
+		url = url.replace(/rocketchat:\/\/|https:\/\/chatbegruenung.de\//, '');
 		const regex = /^(room|auth|invite|shareextension)\?/;
 		const match = url.match(regex);
 		if (match) {

--- a/ios/RocketChatRN/RocketChatRN.entitlements
+++ b/ios/RocketChatRN/RocketChatRN.entitlements
@@ -4,6 +4,10 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:chatbegruenung.de</string>
+	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.app.chatbegruenung</string>


### PR DESCRIPTION
Configure deep links to chatbegruenung.de. Will only work once assetlinks.json and apple-app-site-association are deployed on chatbegruenung.de